### PR TITLE
Larger refactor.

### DIFF
--- a/Assets/ModelReplacementSDK/Editor/ItemOffsetEditor.cs
+++ b/Assets/ModelReplacementSDK/Editor/ItemOffsetEditor.cs
@@ -41,12 +41,12 @@ public class OffsetBuilderEditor : Editor
         }
         EditorGUILayout.Separator();
         EditorGUILayout.LabelField("Controls");
-        EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(OffsetBuilder.renderPlayer)));
-        EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(OffsetBuilder.renderItem)));
-        if (GUILayout.Button("ReZero Model Position"))
+        t.renderPlayer = EditorGUILayout.Toggle("Render Preview Player", t.renderPlayer);
+        t.renderItem = EditorGUILayout.Toggle("Render Preview Item", t.renderItem);
+        if (GUILayout.Button("Reinitialize"))
         {
-            Undo.RecordObject(t, "Calculated root offset");
-            t.CalculateRootOffset();
+            Undo.RecordObject(t, "Reinitialized");
+            t.Initialize(true);
             EditorUtility.SetDirty(t);
         }
 
@@ -57,8 +57,8 @@ public class OffsetBuilderEditor : Editor
     public void OnSceneGUI()
     {
         OffsetBuilder t = (target as OffsetBuilder);
-        Transform handTransform = t.gameObject.GetComponentInChildren<Animator>().GetBoneTransform(HumanBodyBones.RightHand);
-        Transform itemTransform = t.item.transform;
+        //Transform handTransform = t.gameObject.GetComponentInChildren<Animator>().GetBoneTransform(HumanBodyBones.RightHand);
+        //Transform itemTransform = t.item.transform;
 
         Vector3 rootOff = t.rootPositionOffset;
         Vector3 rootSca = t.rootScale;
@@ -89,6 +89,7 @@ public class OffsetBuilderEditor : Editor
 
                 t.itemHolder.transform.SetPositionAndRotation(itemOff, t.itemHolder.transform.rotation);
                 t.itemPositonOffset = t.itemHolder.transform.localPosition;
+                
                 break;
             case Tool.Scale:
                 t.rootScale = rootSca;

--- a/Assets/ModelReplacementSDK/Plugins/OffsetBuilder.cs
+++ b/Assets/ModelReplacementSDK/Plugins/OffsetBuilder.cs
@@ -10,11 +10,14 @@ using UnityEngine;
 
 namespace ModelReplacement.AvatarBodyUpdater
 {
-
     [ExecuteInEditMode]
     [AddComponentMenu("Model Replacement Properties")]
-    public class OffsetBuilder : MonoBehaviour
-    {
+    public class OffsetBuilder : MonoBehaviour {
+        private bool initializedPreview => playerObject != null && item != null;
+        
+        [HideInInspector][SerializeField]
+        private bool initialized;
+        
         public Vector3 rootPositionOffset = new Vector3(0, 0, 0);
         [HideInInspector]
         public Vector3 rootScale = new Vector3(1, 1, 1);
@@ -22,26 +25,25 @@ namespace ModelReplacement.AvatarBodyUpdater
         public Quaternion itemRotationOffset = Quaternion.Euler(328.5828f, 4.848449f, 350.3954f);
         [HideInInspector]
         public GameObject itemHolder;
-        [HideInInspector]
-        public Transform rootTransform;
-
 
 #if UNITY_EDITOR // => Ignore from here to next endif if not in editor
+        public Transform rootTransform => GetPlayerTransformFromBoneName("spine");
         [HideInInspector]
         public GameObject playerObject;
         [HideInInspector]
         public GameObject item;
-        [HideInInspector]
-        public GameObject playerHumanoid;
 
-        public bool renderPlayer = false;
-        public bool renderItem = true;
+        public bool renderPlayer {
+            get => playerObject.GetComponentInChildren<SkinnedMeshRenderer>().enabled;
+            set => playerObject.GetComponentInChildren<SkinnedMeshRenderer>().enabled = value;
+        }
+        public bool renderItem {
+            get => item.GetComponentInChildren<Renderer>().enabled;
+            set => item.GetComponentInChildren<Renderer>().enabled = value;
+        }
 
         public string assetBundleName = "";
         public string assetName = "";
-
-
-
        
         private IEnumerator SaveAssetBundle()
         {
@@ -76,10 +78,98 @@ namespace ModelReplacement.AvatarBodyUpdater
             EditorUtility.RevealInFinder(assetBundleDirectory + "/" + assetBundleName);
         }
 
-        private void OnValidate()
-        {
-            //CalculateScale();
+        private void InitializePreview() {
+            if (initializedPreview) {
+                return;
+            }
 
+            if (playerObject == null)
+            {
+                var playerPrefab = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath("b9abac1e5ff1cb94483598ed4877ae91"));
+                playerObject = (GameObject)PrefabUtility.InstantiatePrefab(playerPrefab);
+                playerObject.hideFlags = HideFlags.DontSave;
+            }
+
+            if (item == null)
+            {
+                var walkieTalkiePrefab = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath("7e73454e50f98f347aaea162c4ebe382"));
+                item = (GameObject)PrefabUtility.InstantiatePrefab(walkieTalkiePrefab);
+                foreach (var itemChild in item.GetComponentsInChildren<Transform>()) {
+                    itemChild.gameObject.hideFlags = HideFlags.DontSave | HideFlags.NotEditable;
+                }
+            }
+            
+            playerObject.name = $"{playerObject.name}({name})";
+            item.name = $"{item.name}({name})";
+        }
+
+        private void CleanUpPreview() {
+            if (Application.isPlaying) {
+                Destroy(item);
+                Destroy(playerObject);
+            } else {
+                DestroyImmediate(item);
+                DestroyImmediate(playerObject);
+            }
+        }
+
+        public void Initialize(bool force) {
+            InitializePreview();
+            if (initialized && !force) {
+                return;
+            }
+
+            assetName = name;
+            animator = GetComponentInChildren<Animator>();
+            if (animator == null)
+            {
+                throw new UnityException("No animator found on the character. It is required.");
+            }
+            Transform upperChestTransform = animator.GetBoneTransform(HumanBodyBones.UpperChest);
+            hasUpperChest = (upperChestTransform != null);
+            
+            var rht = animator.GetBoneTransform(HumanBodyBones.RightHand);
+            if (rht == null) {
+                throw new UnityException("No right hand found on the character. It is required.");
+            }
+
+            if (itemHolder == null) {
+                var itemTransform = rht.Find("ItemHolderTransform");
+                if (itemTransform == null) {
+                    itemHolder = new GameObject("ItemHolderTransform");
+                    itemHolder.transform.SetParent(rht);
+                    itemHolder.name = "ItemHolderTransform";
+                } else {
+                    itemHolder = itemTransform.gameObject;
+                }
+            }
+
+            ScavengerGetter.Get().GetComponentInChildren<Animator>().avatar.humanDescription.skeleton.ToList().ForEach(MapSkeletonBones);
+            animator.avatar.humanDescription.skeleton.ToList().ForEach(MapSkeletonBones);
+            
+            // PopulateFingers();
+            baseScale = Vector3.one;
+            CalculateScale();
+            var playerBodyExtents = playerObject.GetComponentInChildren<SkinnedMeshRenderer>().bounds.extents;
+            float scale = playerBodyExtents.y / GetBounds().extents.y;
+            baseScale = transform.localScale * scale;
+            CalculateScale();
+            CalculateRotationOffsets();
+            CalculateRootOffset();
+            initialized = true;
+        }
+
+        private void MapSkeletonBones(SkeletonBone sk)
+        {
+            var matchingTransforms = GetComponentsInChildren<Transform>().Where(x => x.name == sk.name);
+            if (matchingTransforms.Any())
+            {
+                matchingTransforms.First().localRotation = sk.rotation;
+            }
+            else
+            {
+                Debug.Log($"Missing bone {sk.name}");
+            }
         }
 
         public void SaveAssetBundles()
@@ -92,7 +182,7 @@ namespace ModelReplacement.AvatarBodyUpdater
         private Bounds GetBounds()
         {
             Bounds bounds = new Bounds();
-            var allBounds = base.gameObject.GetComponentsInChildren<SkinnedMeshRenderer>().Select(r => r.bounds);
+            var allBounds = gameObject.GetComponentsInChildren<SkinnedMeshRenderer>().Select(r => r.bounds);
 
             float maxX = allBounds.OrderByDescending(x => x.max.x).First().max.x;
             float maxY = allBounds.OrderByDescending(x => x.max.y).First().max.y;
@@ -102,118 +192,11 @@ namespace ModelReplacement.AvatarBodyUpdater
             float minY = allBounds.OrderBy(x => x.min.y).First().min.y;
             float minZ = allBounds.OrderBy(x => x.min.z).First().min.z;
 
-            bounds.SetMinMax(new Vector3(minX, minY, minZ), new Vector3(maxZ, maxY, maxZ));
+            bounds.SetMinMax(new Vector3(minX, minY, minZ), new Vector3(maxX, maxY, maxZ));
             return bounds;
         }
 
-        // Start is called before the first frame update
-        void Start()
-        {
-            if (playerObject != null) { return; }
-            UnityEngine.Object playerPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath("b9abac1e5ff1cb94483598ed4877ae91"), typeof(GameObject)); 
-            UnityEngine.Object walkieTalkiePrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath("7e73454e50f98f347aaea162c4ebe382"), typeof(GameObject));
-            UnityEngine.Object scavengerPrefab = AssetDatabase.LoadAssetAtPath(AssetDatabase.GUIDToAssetPath("a024259985699eb4fb6d4585e872c37c"), typeof(GameObject));
-            playerObject = (GameObject)PrefabUtility.InstantiatePrefab(playerPrefab);
-            item = (GameObject)PrefabUtility.InstantiatePrefab(walkieTalkiePrefab);
-            playerHumanoid = (GameObject)PrefabUtility.InstantiatePrefab(scavengerPrefab);
-            playerObject.name = playerObject.name + $"({base.name})";
-            item.name = item.name + $"({base.name})";
-            playerHumanoid.name = playerHumanoid.name + $"({base.name})";
-
-            assetName = base.name;
-
-            animator = base.GetComponentInChildren<Animator>();
-            Transform upperChestTransform = animator.GetBoneTransform(HumanBodyBones.UpperChest);
-            hasUpperChest = (upperChestTransform != null);
-
-            rootTransform = GetPlayerTransformFromBoneName("spine");
-
-            var rht = animator.GetBoneTransform(HumanBodyBones.RightHand);
-            for (int i = 0; i < rht.childCount; i++)
-            {
-                Transform cht = rht.GetChild(i);
-                if (cht.name == "ItemHolderTransform")
-                {
-                    itemHolder = cht.gameObject;
-                }
-            }
-            if(itemHolder == null)
-            {
-                var tempgo = new GameObject("ItemHolderTransform");
-                itemHolder = GameObject.Instantiate(tempgo, rht);
-                DestroyImmediate(tempgo);
-                itemHolder.name = "ItemHolderTransform";
-                itemHolder.transform.parent = rht;
-            }
-
-
-            playerHumanoid.GetComponentInChildren<Animator>().avatar.humanDescription.skeleton.ToList().ForEach(sk =>
-            {
-                var a = playerHumanoid.GetComponentsInChildren<Transform>().Where(x => x.name == sk.name);
-                if (a.Any())
-                {
-                    a.First().localRotation = sk.rotation;
-                }
-                else
-                {
-                    Debug.Log($"Missing bone {sk.name}");
-                }
-
-            });
-            animator.avatar.humanDescription.skeleton.ToList().ForEach(sk =>
-            {
-                var a = base.GetComponentsInChildren<Transform>().Where(x => x.name == sk.name);
-                if (a.Any())
-                {
-                    a.First().localRotation = sk.rotation;
-                }
-                else
-                {
-                    Debug.Log($"Missing bone {sk.name}");
-                }
-            });
-            var playerBodyExtents = playerObject.GetComponentInChildren<SkinnedMeshRenderer>().bounds.extents;
-            float scale = playerBodyExtents.y / GetBounds().extents.y;
-            base.transform.localScale *= scale;
-           // PopulateFingers();
-            baseScale = base.transform.localScale;
-            CalculateScale();
-            CalculateRotationOffsets();
-            CalculateRootOffset();
-
-
-
-        }
-        /*
-        public void PopulateFingers()
-        {
-            if(fingerDrivers.Count != 0) { return; }
-            fingerDrivers = new List<FingerDriver>();
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger5.L"), GetPlayerTransformFromBoneName("finger5.L.001"),
-                animator.GetBoneTransform(HumanBodyBones.LeftLittleProximal), animator.GetBoneTransform(HumanBodyBones.LeftLittleIntermediate), animator.GetBoneTransform(HumanBodyBones.LeftLittleDistal)));
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger4.L"), GetPlayerTransformFromBoneName("finger4.L.001"),
-                animator.GetBoneTransform(HumanBodyBones.LeftRingProximal), animator.GetBoneTransform(HumanBodyBones.LeftRingIntermediate), animator.GetBoneTransform(HumanBodyBones.LeftRingDistal)));
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger3.L"), GetPlayerTransformFromBoneName("finger3.L.001"),
-                animator.GetBoneTransform(HumanBodyBones.LeftMiddleProximal), animator.GetBoneTransform(HumanBodyBones.LeftMiddleIntermediate), animator.GetBoneTransform(HumanBodyBones.LeftMiddleDistal)));
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger2.L"), GetPlayerTransformFromBoneName("finger2.L.001"),
-                animator.GetBoneTransform(HumanBodyBones.LeftIndexProximal), animator.GetBoneTransform(HumanBodyBones.LeftIndexIntermediate), animator.GetBoneTransform(HumanBodyBones.LeftIndexDistal)));
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger1.L"), GetPlayerTransformFromBoneName("finger1.L.001"),
-                animator.GetBoneTransform(HumanBodyBones.LeftThumbProximal), animator.GetBoneTransform(HumanBodyBones.LeftThumbIntermediate), animator.GetBoneTransform(HumanBodyBones.LeftThumbDistal)));
-
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger5.R"), GetPlayerTransformFromBoneName("finger5.R.001"),
-                animator.GetBoneTransform(HumanBodyBones.RightLittleProximal), animator.GetBoneTransform(HumanBodyBones.RightLittleIntermediate), animator.GetBoneTransform(HumanBodyBones.RightLittleDistal)));
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger4.R"), GetPlayerTransformFromBoneName("finger4.R.001"),
-                animator.GetBoneTransform(HumanBodyBones.RightRingProximal), animator.GetBoneTransform(HumanBodyBones.RightRingIntermediate), animator.GetBoneTransform(HumanBodyBones.RightRingDistal)));
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger3.R"), GetPlayerTransformFromBoneName("finger3.R.001"),
-                animator.GetBoneTransform(HumanBodyBones.RightMiddleProximal), animator.GetBoneTransform(HumanBodyBones.RightMiddleIntermediate), animator.GetBoneTransform(HumanBodyBones.RightMiddleDistal)));
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger2.R"), GetPlayerTransformFromBoneName("finger2.R.001"),
-                animator.GetBoneTransform(HumanBodyBones.RightIndexProximal), animator.GetBoneTransform(HumanBodyBones.RightIndexIntermediate), animator.GetBoneTransform(HumanBodyBones.RightIndexDistal)));
-            fingerDrivers.Add(new FingerDriver(GetPlayerTransformFromBoneName("finger1.R"), GetPlayerTransformFromBoneName("finger1.R.001"),
-                animator.GetBoneTransform(HumanBodyBones.RightThumbProximal), animator.GetBoneTransform(HumanBodyBones.RightThumbIntermediate), animator.GetBoneTransform(HumanBodyBones.RightThumbDistal)));
-        }
-        */
-
-        public Vector3 baseScale = Vector3.zero;
+        public Vector3 baseScale = Vector3.one;
         public static List<string> DontCalculateOffset = new List<string>()
         {
                 "finger5.L" ,
@@ -241,7 +224,6 @@ namespace ModelReplacement.AvatarBodyUpdater
 
         public void CalculateScale()
         {
-            if(playerObject == null) return;
             transform.localScale = Vector3.Scale(baseScale,rootScale);
         }
 
@@ -253,11 +235,9 @@ namespace ModelReplacement.AvatarBodyUpdater
                 if (modelBone == null) { continue; }
 
 
-
                 Transform humanBone = null;
-                var someBones = playerHumanoid.GetComponentsInChildren<Transform>().Where(x => x.name == playerBone.name.Replace(".", "_"));
+                var someBones = ScavengerGetter.Get().GetComponentsInChildren<Transform>().Where(x => x.name == playerBone.name.Replace(".", "_"));
                 if (someBones.Any()) { humanBone = someBones.First(); }
-
 
 
                 if (!modelBone.gameObject.GetComponent<RotationOffset>())
@@ -267,44 +247,38 @@ namespace ModelReplacement.AvatarBodyUpdater
                     if (humanBone )
                     {
                         a.offset = Quaternion.Inverse(playerBone.rotation) * modelBone.rotation;
-
                     }
                 }
 
             }
         }
+
         public void CalculateRootOffset()
         {
             //Translation offset done after all rotation offsets are done
             foreach (Transform playerBone in playerObject.GetComponentInChildren<SkinnedMeshRenderer>().bones)
             {
+                if (playerBone.name != "spine") continue;
+                    
                 Transform modelBone = GetAvatarTransformFromBoneName(playerBone.name);
                 if (modelBone == null) { continue; }
 
-                if (playerBone.name == "spine")
-                {
-                    Vector3 playerfoot = playerHumanoid.GetComponentInChildren<Animator>().GetBoneTransform(HumanBodyBones.LeftToes).position;
-                    Vector3 modelFoot = GetAvatarLowestTransform().position;
-                    Vector3 diff = playerfoot - modelFoot;
-                    diff.x = 0f;
-                    diff.y *= -1;
-                    rootPositionOffset = playerBone.InverseTransformVector(diff);
-                    //rootPositionOffset = diff;
-                }
+                Vector3 playerfoot = ScavengerGetter.Get().GetComponentInChildren<Animator>().GetBoneTransform(HumanBodyBones.LeftToes).position;
+                Vector3 modelFoot = GetAvatarLowestTransform().position + playerBone.TransformVector(rootPositionOffset);
+                Vector3 diff = playerfoot - modelFoot;
+                diff.x = 0f;
+                rootPositionOffset = playerBone.InverseTransformVector(diff);
             }
         }
 
         // Update is called once per frame
-        void Update()
-        {
-            if (playerObject == null) { return; }
-           // PopulateFingers();
+        void Update() {
+            if (!initializedPreview) { return; }
+            // PopulateFingers();
             playerObject.GetComponentInChildren<SkinnedMeshRenderer>().enabled = renderPlayer;
             item.GetComponentInChildren<Renderer>().enabled = renderItem;
             CalculateScale();
-            // playerObject.GetComponentsInChildren<Renderer>().ToList().ForEach(r => r.enabled = false);
-            animator = base.GetComponentInChildren<Animator>();
-            //Debug.Log($"Bones {playerObject.GetComponentInChildren<SkinnedMeshRenderer>().bones.Count()}");
+            animator = GetComponentInChildren<Animator>();
 
 
             itemHolder.transform.localPosition = itemPositonOffset;
@@ -335,13 +309,13 @@ namespace ModelReplacement.AvatarBodyUpdater
             }
         }
 
-        private void OnDestroy()
-        {
-            DestroyImmediate(item);
-            DestroyImmediate(playerObject);
-            DestroyImmediate(playerHumanoid);
+        private void OnEnable() {
+            Initialize(false);
         }
 
+        private void OnDisable() {
+            CleanUpPreview();
+        }
 
         private Transform GetAvatarLowestTransform()
         {
@@ -399,8 +373,6 @@ namespace ModelReplacement.AvatarBodyUpdater
             return null;
 
         }
-
-        
 
         //Remove spine.002 and .003 to implement logic
         public static Dictionary<string, HumanBodyBones> modelToAvatarBone = new Dictionary<string, HumanBodyBones>()

--- a/Assets/ModelReplacementSDK/Plugins/ScavengerGetter.cs
+++ b/Assets/ModelReplacementSDK/Plugins/ScavengerGetter.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+
+public static class ScavengerGetter {
+    private static GameObject originalScavenger;
+    public static GameObject Get() {
+        if (originalScavenger == null) {
+            originalScavenger = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath("a024259985699eb4fb6d4585e872c37c"));
+        }
+        return originalScavenger;
+    }
+}
+
+#endif

--- a/Assets/ModelReplacementSDK/Plugins/ScavengerGetter.cs.meta
+++ b/Assets/ModelReplacementSDK/Plugins/ScavengerGetter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9694add7b2771a4b9fc54b58c287803
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Instead of instantiating a new Scavenger to read the "original", just read it straight off disk. Created a class dedicated to retrieving a "read-only" version of the scavenger. I know this sounds less safe, but it's actually immutable in packages for all users, and won't save anything unless an Undo State or SetDirty is called on it.
- RenderPlayer, and RenderItem are no longer serialized. They've been turned into getters/setters that directly affect the respective renderers. This prevents them from needing to be set during Update(); I also named them to have the keyword "preview" so users know they aren't a tangible setting.
    - Also, HideFlags have been set on the preview objects so they don't get saved to the scene or within prefabs. The walkie talkie in particular has been made uneditable. (Should consider hiding it from the hierarchy too).
- Rezero Root Position has been switched to be a "Reinitialize" button, which will force refresh all calculations (including re-zeroing the model). This is an alternative to refreshing everything every time the script loads.
- RootTransform is unused in the api, and references a Missing on build anyhow, so it has been moved into UNITY_EDITOR only code.

Some small bugs I detected through this as well:
- Fixed CalculateRootPosition not taking original root offset into account. 
- Fixed GetBounds() generating a 0 width X boundary due to a typo.
- RootTransform was unused and serialized an immutable, transient asset.