### PR TITLE
Replace MapSkeletonBones with ForceRestPose

### DIFF
--- a/Assets/ModelReplacementSDK/Plugins/OffsetBuilder.cs
+++ b/Assets/ModelReplacementSDK/Plugins/OffsetBuilder.cs
@@ -209,7 +209,7 @@ namespace ModelReplacement.AvatarBodyUpdater
                 matchingTransforms.AddRange(childTransforms.Where(x => x.name == sk.name));
                 if (matchingTransforms.Count > 0)
                 {
-                    if (matchingTransforms.Count > 0)
+                    if (matchingTransforms.Count > 1)
                     {
                         Debug.LogWarning($"Ambiguous match: bone '{sk.name}' matches multiple transforms");
                     }


### PR DESCRIPTION
Fixes #18 by ignoring the root transform which often shares the same name with the mesh object, and also warns of ambiguous bones.